### PR TITLE
Fix -uniq skipping the next argument

### DIFF
--- a/src/fragSim.cpp
+++ b/src/fragSim.cpp
@@ -480,7 +480,6 @@ int main (int argc, char *argv[]) {
 
 	if(string(argv[i]) == "-uniq" ){
 	    uniqTags = true;
-	    i++; 
 	    continue;
 	}
 


### PR DESCRIPTION
The `-uniq` option is documented as a flag, but fragSim skips the value following `-uniq` and it therefore requires the use of a dummy value: `fragSim -uniq unused-value [...]`